### PR TITLE
Add labels array in MergeRequestEventPayload

### DIFF
--- a/gitlab/payload.go
+++ b/gitlab/payload.go
@@ -56,6 +56,7 @@ type MergeRequestEventPayload struct {
 	Changes          Changes          `json:"changes"`
 	Project          Project          `json:"project"`
 	Repository       Repository       `json:"repository"`
+	Labels           []Label          `json:"labels"`
 }
 
 // PushEventPayload contains the information for GitLab's push event


### PR DESCRIPTION
Grab this commit from the go-playground/webhooks origin repo to add support for labels in GitLab MergeRequestEventPayload: 4156f32687854ec32234ca3f5c7f7ad62991a134

When GitLab creates a new MR, labels are _not_ add to `Changes`, but they are available in the `labels` array in the hook payload. 
